### PR TITLE
Update smart-breaker.js

### DIFF
--- a/src/smart-breaker.js
+++ b/src/smart-breaker.js
@@ -1,5 +1,5 @@
 import Quill from 'quill';
-import Delta from 'quill-delta/dist/Delta';
+import Delta from 'quill-delta';
 import SmartBreak from './blots/smart-break';
 
 class SmartBreaker {


### PR DESCRIPTION
* updated reference to Delta dependency (there was an error when importing quill-smart-break, specifically in Nuxt)